### PR TITLE
Added test for isDebianDistribution and isUbuntuDistribution to correct building Ubuntu debs on Ubuntu

### DIFF
--- a/src/main/java/com/rm5248/debianpbuilder/DebianPbuilder.java
+++ b/src/main/java/com/rm5248/debianpbuilder/DebianPbuilder.java
@@ -149,6 +149,50 @@ public class DebianPbuilder extends Builder implements SimpleBuildStep {
         
         return debianDirLocation;
     }
+
+    public boolean isDebianDistribution(){
+       switch(distribution.toLowerCase()) {
+          case "buzz":
+          case "rex":
+          case "bo":
+          case "hamm":
+          case "slink":
+          case "potato":
+          case "woody":
+          case "sarge":
+          case "etch":
+          case "lenny":
+          case "squeeze":
+          case "wheezy":
+          case "jessie":
+          case "stretch":
+          case "buster":
+          case "bullseye":
+          case "sid":
+            return true;
+       }
+       return false;
+    }
+
+    public boolean isUbuntuDistribution(){
+       switch(distribution.toLowerCase()) {
+          case "bionic":
+          case "artful":
+          case "xenial":
+          case "trusty":
+          case "zesty":
+          case "yakkety":
+          case "wiley":
+          case "vivid":
+          case "utopic":
+          case "saucy":
+          case "raring":
+          case "quantal":
+          case "precise":
+            return true;
+       }
+       return false;
+    }
     
     @Override
     public void perform(Run<?,?> run, FilePath workspace, Launcher launcher, TaskListener listener )
@@ -289,7 +333,7 @@ public class DebianPbuilder extends Builder implements SimpleBuildStep {
             pbuildConfig.setAdditionalBuildResults( additionalBuildResults.split( "," ) );
         }
         
-        if( isUbuntu( workspace, launcher, listener ) ){
+        if( isUbuntu( workspace, launcher, listener ) && isDebianDistribution() ){
             pbuildConfig.setDebootstrapOpts( "--keyring", "/usr/share/keyrings/debian-archive-keyring.gpg" );
         }
         


### PR DESCRIPTION
I am building a xenial package on a bionic box.

The current cowbuilder command created is:

`sudo cowbuilder --create --basepath /var/cache/pbuilder/base-xenial-amd64 --distribution xenial --debootstrap debootstrap --architecture amd64 --debootstrapopts --arch --debootstrapopts amd64 --debootstrapopts --variant=buildd --configfile /var/lib/jenkins/workspace/test-project/pbuilderrc6804862912072590958.tmp --hookdir /var/lib/jenkins/workspace/test-project/hookdir`

This results in a few errors including:
`E: Release signed by unknown key (key id 3B4FE6ACC0B21F32)`

because of the option "--keyring=/usr/share/keyrings/debian-archive-keyring.gpg" being written to the pbuilderrc.tmp file.

(I am not a Java programmer, so!) I added a couple methods, one used, one anticipated. Extended the test to write the keyring only if this is package for a Debian distro being built on an Ubuntu box. If it is Ubuntu on Ubuntu then this keyring value is undesirable.

Thanks!
Jay